### PR TITLE
Use Cron+ and Home Assistant nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Node-Red Implementation of the Smart Meter Texas API
 
-Access your current meter reading from the Smart Meter Texas API!  The Node-Red flow requests a meter read every hour and reports the results over MQTT.  There is also a package for Home Assistant providing a number of useful sensors for use in your home.
+Access your current meter reading from the Smart Meter Texas API!  The Node-Red flow requests a meter read every hour and reports the results as a sensor in Home Assistant.
 
 ---
 ### Prerequisites:
 * An electric meter enrolled with Smart Meter Texas
 * Your Smart Meter Texas Username, Password, ESIID, and Meter Number
-* An MQTT Server
+* Home Assistant, with the NodeRED Custom Component installed (to create sensors from NodeRED)
 * Node-Red and the following additional nodes:
    * node-red-contrib-home-assistant-websocket (if you use Home Assistant)
    * node-red-contrib-https
@@ -27,7 +27,7 @@ Access your current meter reading from the Smart Meter Texas API!  The Node-Red 
 4. If you are using the Home Assistant package, set your electricity cost in the entity __input_number.smt_energy_cost__.
 ---
 ### Usage:
-The Node-Red flow will request a meter read at 30 minute intervals since the last successful read.  It will then request the results of the meter read every 30 seconds until they are available.  The current meter reading is reported over MQTT with the topic smt/reading.  
+The Node-Red flow will request a meter read at 30 minute intervals since the last successful read.  It will then request the results of the meter read every 30 seconds until they are available.  A sensor will be created in Home Assistant (if using the custom component) with the current meter reading.
 
 Note that the API limits each ESIID to two reads per hour and 24 reads per day.  The limit is based on the time when the reading is successfully retrieved from the meter.  Increasing the frequency of reads will result in an error until the hour or day resets (depending on the error).
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Access your current meter reading from the Smart Meter Texas API!  The Node-Red 
 * Your Smart Meter Texas Username, Password, ESIID, and Meter Number
 * An MQTT Server
 * Node-Red and the following additional nodes:
-   * node-red-contrib-config
+   * node-red-contrib-home-assistant-websocket (if you use Home Assistant)
    * node-red-contrib-https
    * node-red-contrib-credentials
+   * node-red-contrib-cron-plus
+
 ---
 ### Installation:
 1. Make sure your system meets the above prerequisites.
@@ -19,8 +21,8 @@ Access your current meter reading from the Smart Meter Texas API!  The Node-Red 
 4. Continue with configuration!
 ---
 ### Configuration:
-1. Open the imported Node-Red flow and open the __Credentials__ node.  You will need to fill in your Smart Meter Texas Username, Password, ESIID, and Meter Number.  Optionally, you can change the minute when the meter will be polled every hour in the __Configuration__ node.  Click __Done__ when you are finished.
-2. Open the __MQTT: Send Reading__ node and configure your MQTT server information.
+1. Open the imported Node-Red flow and open the __Credentials__ node.  You will need to fill in your Smart Meter Texas Username, Password, ESIID, and Meter Number.  Optionally, you can change the minute when the meter will be polled every hour in the __Cron+__ nodes.  Click __Done__ when you are finished.
+2. Open the __SMT Current Reading__ node and configure your Home Assistant server information.
 3. When you are finished configuring the nodes, click the __Deploy__ button to start the flow with your new configuration.
 4. If you are using the Home Assistant package, set your electricity cost in the entity __input_number.smt_energy_cost__.
 ---

--- a/smart_meter_texas.json
+++ b/smart_meter_texas.json
@@ -584,11 +584,11 @@
     "attributes": [{
         "property": "odr_date",
         "value": "payload.data.odrdate",
-        "valueType": "str"
+        "valueType": "msg"
     }, {
         "property": "odr_usage",
         "value": "payload.data.odrusage",
-        "valueType": "str"
+        "valueType": "msg"
     }],
     "resend": true,
     "outputLocation": "",

--- a/smart_meter_texas.json
+++ b/smart_meter_texas.json
@@ -1,790 +1,602 @@
-[
-    {
-        "id": "f8297485.d32748",
-        "type": "tab",
-        "label": "Smart Meter Texas",
-        "disabled": false,
-        "info": ""
-    },
-    {
-        "id": "229dbc53.b39f84",
-        "type": "inject",
-        "z": "f8297485.d32748",
-        "name": "Retrieve Reading",
-        "topic": "",
+[{
+    "id": "f8297485.d32748",
+    "type": "tab",
+    "label": "Smart Meter Texas",
+    "disabled": false,
+    "info": ""
+}, {
+    "id": "229dbc53.b39f84",
+    "type": "inject",
+    "z": "f8297485.d32748",
+    "name": "Retrieve Reading",
+    "props": [{
+        "p": "payload",
+        "v": "",
+        "vt": "date"
+    }, {
+        "p": "topic",
+        "v": "",
+        "vt": "string"
+    }],
+    "repeat": "30",
+    "crontab": "",
+    "once": true,
+    "onceDelay": "1.0",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 130,
+    "y": 460,
+    "wires": [
+        ["49de2e1c.6a2d7"]
+    ]
+}, {
+    "id": "f805b5.98485a48",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "Apply HTTP Config",
+    "rules": [{
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "resultjson",
+        "tot": "flow"
+    }, {
+        "t": "set",
+        "p": "headers.content-type",
+        "pt": "msg",
+        "to": "application/json",
+        "tot": "str"
+    }, {
+        "t": "set",
+        "p": "headers.authorization",
+        "pt": "msg",
+        "to": "token",
+        "tot": "flow"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 550,
+    "y": 460,
+    "wires": [
+        ["cfcca3db.82497"]
+    ]
+}, {
+    "id": "45fd4f16.4d205",
+    "type": "switch",
+    "z": "f8297485.d32748",
+    "name": "Status Complete",
+    "property": "payload.data.odrstatus",
+    "propertyType": "msg",
+    "rules": [{
+        "t": "eq",
+        "v": "COMPLETED",
+        "vt": "str"
+    }],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 1,
+    "x": 900,
+    "y": 480,
+    "wires": [
+        ["f35231ec.019d9"]
+    ]
+}, {
+    "id": "8f12d0a3.66f63",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "Apply HTTP Config",
+    "rules": [{
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "authjson",
+        "tot": "flow"
+    }, {
+        "t": "set",
+        "p": "headers.content-type",
+        "pt": "msg",
+        "to": "application/json",
+        "tot": "str"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 290,
+    "y": 260,
+    "wires": [
+        ["f2f055cc.fa05f8"]
+    ]
+}, {
+    "id": "5a67264f.b0d4a8",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "",
+    "rules": [{
+        "t": "set",
+        "p": "token",
+        "pt": "flow",
+        "to": "payload",
+        "tot": "msg"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 760,
+    "y": 280,
+    "wires": [
+        ["197f7fb8.eb7b3"]
+    ]
+}, {
+    "id": "9e15d26d.67d59",
+    "type": "debug",
+    "z": "f8297485.d32748",
+    "name": "Debug: Login",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "x": 590,
+    "y": 240,
+    "wires": []
+}, {
+    "id": "4b59cb1f.0b6074",
+    "type": "function",
+    "z": "f8297485.d32748",
+    "name": "Add Bearer",
+    "func": "msg.payload = \"bearer \" + msg.payload.token;\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "x": 590,
+    "y": 280,
+    "wires": [
+        ["5a67264f.b0d4a8"]
+    ]
+}, {
+    "id": "a33f45a0.ca8a88",
+    "type": "inject",
+    "z": "f8297485.d32748",
+    "name": "Build JSON",
+    "props": [{
+        "p": "payload",
+        "v": "",
+        "vt": "date"
+    }, {
+        "p": "topic",
+        "v": "",
+        "vt": "string"
+    }],
+    "repeat": "",
+    "crontab": "",
+    "once": true,
+    "onceDelay": "0.1",
+    "topic": "",
+    "payload": "",
+    "payloadType": "date",
+    "x": 110,
+    "y": 140,
+    "wires": [
+        ["4779bbf2.421be4"]
+    ]
+}, {
+    "id": "eca68eef.a7038",
+    "type": "function",
+    "z": "f8297485.d32748",
+    "name": "Create Login JSON",
+    "func": "msg.payload = {\n  \"username\": msg.username,\n  \"password\": msg.password,\n  \"rememberMe\": \"true\"\n};\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "x": 470,
+    "y": 100,
+    "wires": [
+        ["39f969.672e1698"]
+    ]
+}, {
+    "id": "b72628a.cba9fd8",
+    "type": "function",
+    "z": "f8297485.d32748",
+    "name": "Create Read Request JSON",
+    "func": "msg.payload = {\n  \"ESIID\": msg.esiid,\n  \"MeterNumber\": msg.meternumber\n};\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "x": 500,
+    "y": 140,
+    "wires": [
+        ["896ca32e.dd642"]
+    ]
+}, {
+    "id": "4f766b51.f67344",
+    "type": "function",
+    "z": "f8297485.d32748",
+    "name": "Create Read Result JSON",
+    "func": "msg.payload = {\n  \"ESIID\": msg.esiid\n};\nreturn msg;",
+    "outputs": 1,
+    "noerr": 0,
+    "x": 490,
+    "y": 180,
+    "wires": [
+        ["33a32576.b8d44a"]
+    ]
+}, {
+    "id": "49de2e1c.6a2d7",
+    "type": "switch",
+    "z": "f8297485.d32748",
+    "name": "Waiting for Response",
+    "property": "readrequested",
+    "propertyType": "flow",
+    "rules": [{
+        "t": "eq",
+        "v": "1",
+        "vt": "str"
+    }],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 1,
+    "x": 340,
+    "y": 460,
+    "wires": [
+        ["f805b5.98485a48"]
+    ]
+}, {
+    "id": "f35231ec.019d9",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "Not Waiting for Response",
+    "rules": [{
+        "t": "set",
+        "p": "readrequested",
+        "pt": "flow",
+        "to": "0",
+        "tot": "str"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 1120,
+    "y": 480,
+    "wires": [
+        ["8e5e4167.3de6a"]
+    ]
+}, {
+    "id": "39f969.672e1698",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "",
+    "rules": [{
+        "t": "set",
+        "p": "authjson",
+        "pt": "flow",
+        "to": "payload",
+        "tot": "msg"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 720,
+    "y": 100,
+    "wires": [
+        []
+    ]
+}, {
+    "id": "896ca32e.dd642",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "",
+    "rules": [{
+        "t": "set",
+        "p": "readjson",
+        "pt": "flow",
+        "to": "payload",
+        "tot": "msg"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 720,
+    "y": 140,
+    "wires": [
+        []
+    ]
+}, {
+    "id": "33a32576.b8d44a",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "",
+    "rules": [{
+        "t": "set",
+        "p": "resultjson",
+        "pt": "flow",
+        "to": "payload",
+        "tot": "msg"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 730,
+    "y": 180,
+    "wires": [
+        []
+    ]
+}, {
+    "id": "8a692061.c38d8",
+    "type": "switch",
+    "z": "f8297485.d32748",
+    "name": "Request Good",
+    "property": "payload.data.statusReason",
+    "propertyType": "msg",
+    "rules": [{
+        "t": "eq",
+        "v": "Request submitted successfully for further processing",
+        "vt": "str"
+    }],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 1,
+    "x": 660,
+    "y": 380,
+    "wires": [
+        ["41ccc9f0.cb5378"]
+    ]
+}, {
+    "id": "41ccc9f0.cb5378",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "Waiting for Response",
+    "rules": [{
+        "t": "set",
+        "p": "readrequested",
+        "pt": "flow",
+        "to": "1",
+        "tot": "str"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 860,
+    "y": 380,
+    "wires": [
+        []
+    ]
+}, {
+    "id": "ba8a2ae2.a4c338",
+    "type": "debug",
+    "z": "f8297485.d32748",
+    "name": "Debug: Get Reading",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "x": 910,
+    "y": 440,
+    "wires": []
+}, {
+    "id": "a411cabf.0a9678",
+    "type": "change",
+    "z": "f8297485.d32748",
+    "name": "Apply HTTP Config",
+    "rules": [{
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "readjson",
+        "tot": "flow"
+    }, {
+        "t": "set",
+        "p": "headers.content-type",
+        "pt": "msg",
+        "to": "application/json",
+        "tot": "str"
+    }, {
+        "t": "set",
+        "p": "headers.authorization",
+        "pt": "msg",
+        "to": "token",
+        "tot": "flow"
+    }],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 290,
+    "y": 360,
+    "wires": [
+        ["1e663d0f.337c23"]
+    ]
+}, {
+    "id": "616cab00.8d1ed4",
+    "type": "debug",
+    "z": "f8297485.d32748",
+    "name": "Debug: Read Meter",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "x": 670,
+    "y": 340,
+    "wires": []
+}, {
+    "id": "197f7fb8.eb7b3",
+    "type": "debug",
+    "z": "f8297485.d32748",
+    "name": "Debug: Auth Token",
+    "active": false,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "payload",
+    "targetType": "msg",
+    "x": 950,
+    "y": 280,
+    "wires": []
+}, {
+    "id": "cfcca3db.82497",
+    "type": "https-node",
+    "z": "f8297485.d32748",
+    "name": "Get Reading",
+    "method": "POST",
+    "ret": "obj",
+    "url": "https://smartmetertexas.com/api/usage/latestodrread",
+    "authorized": false,
+    "agent": true,
+    "x": 730,
+    "y": 460,
+    "wires": [
+        ["45fd4f16.4d205", "ba8a2ae2.a4c338"]
+    ]
+}, {
+    "id": "f2f055cc.fa05f8",
+    "type": "https-node",
+    "z": "f8297485.d32748",
+    "name": "Log In",
+    "method": "POST",
+    "ret": "obj",
+    "url": "https://smartmetertexas.com/api/user/authenticate",
+    "authorized": false,
+    "agent": true,
+    "x": 450,
+    "y": 260,
+    "wires": [
+        ["4b59cb1f.0b6074", "9e15d26d.67d59"]
+    ]
+}, {
+    "id": "1e663d0f.337c23",
+    "type": "https-node",
+    "z": "f8297485.d32748",
+    "name": "Request Read",
+    "method": "POST",
+    "ret": "obj",
+    "url": "https://smartmetertexas.com/api/ondemandread",
+    "authorized": false,
+    "agent": true,
+    "x": 480,
+    "y": 360,
+    "wires": [
+        ["8a692061.c38d8", "616cab00.8d1ed4"]
+    ]
+}, {
+    "id": "4779bbf2.421be4",
+    "type": "credentials",
+    "z": "f8297485.d32748",
+    "name": "Credentials",
+    "props": [{
+        "value": "username",
+        "type": "msg"
+    }, {
+        "value": "password",
+        "type": "msg"
+    }, {
+        "value": "esiid",
+        "type": "msg"
+    }, {
+        "value": "meternumber",
+        "type": "msg"
+    }],
+    "x": 270,
+    "y": 140,
+    "wires": [
+        ["eca68eef.a7038", "b72628a.cba9fd8", "4f766b51.f67344"]
+    ]
+}, {
+    "id": "605199a9.192288",
+    "type": "cronplus",
+    "z": "f8297485.d32748",
+    "name": "Read Meter",
+    "outputField": "payload",
+    "timeZone": "",
+    "options": [{
+        "topic": "50 min past the hour",
         "payload": "",
-        "payloadType": "date",
-        "repeat": "30",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1.0",
-        "x": 130,
-        "y": 460,
-        "wires": [
-            [
-                "49de2e1c.6a2d7"
-            ]
-        ]
-    },
-    {
-        "id": "f805b5.98485a48",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Apply HTTP Config",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "resultjson",
-                "tot": "flow"
-            },
-            {
-                "t": "set",
-                "p": "headers.content-type",
-                "pt": "msg",
-                "to": "application/json",
-                "tot": "str"
-            },
-            {
-                "t": "set",
-                "p": "headers.authorization",
-                "pt": "msg",
-                "to": "token",
-                "tot": "flow"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 550,
-        "y": 460,
-        "wires": [
-            [
-                "cfcca3db.82497"
-            ]
-        ]
-    },
-    {
-        "id": "cfcca3db.82497",
-        "type": "https-node",
-        "z": "f8297485.d32748",
-        "name": "Get Reading",
-        "method": "POST",
-        "ret": "obj",
-        "url": "https://smartmetertexas.com/api/usage/latestodrread",
-        "authorized": false,
-        "agent": true,
-        "x": 730,
-        "y": 460,
-        "wires": [
-            [
-                "45fd4f16.4d205",
-                "ba8a2ae2.a4c338"
-            ]
-        ]
-    },
-    {
-        "id": "45fd4f16.4d205",
-        "type": "switch",
-        "z": "f8297485.d32748",
-        "name": "Status Complete",
-        "property": "payload.data.odrstatus",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "COMPLETED",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 900,
-        "y": 480,
-        "wires": [
-            [
-                "f35231ec.019d9"
-            ]
-        ]
-    },
-    {
-        "id": "9b94f423.af26c8",
-        "type": "inject",
-        "z": "f8297485.d32748",
-        "name": "Authenticate",
-        "topic": "",
+        "type": "str",
+        "expression": "0 50 * * * * "
+    }],
+    "x": 110,
+    "y": 360,
+    "wires": [
+        ["a411cabf.0a9678"]
+    ]
+}, {
+    "id": "952a9f1b.63456",
+    "type": "cronplus",
+    "z": "f8297485.d32748",
+    "name": "Authenticate",
+    "outputField": "payload",
+    "timeZone": "",
+    "options": [{
+        "topic": "49 min past the hour",
         "payload": "",
-        "payloadType": "date",
-        "repeat": "1",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "0.5",
-        "x": 110,
-        "y": 260,
-        "wires": [
-            [
-                "a4d10d90.f8dae"
-            ]
-        ]
-    },
-    {
-        "id": "8f12d0a3.66f63",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Apply HTTP Config",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "authjson",
-                "tot": "flow"
-            },
-            {
-                "t": "set",
-                "p": "headers.content-type",
-                "pt": "msg",
-                "to": "application/json",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 580,
-        "y": 260,
-        "wires": [
-            [
-                "f2f055cc.fa05f8"
-            ]
-        ]
-    },
-    {
-        "id": "f2f055cc.fa05f8",
-        "type": "https-node",
-        "z": "f8297485.d32748",
-        "name": "Log In",
-        "method": "POST",
-        "ret": "obj",
-        "url": "https://smartmetertexas.com/api/user/authenticate",
-        "authorized": false,
-        "agent": true,
-        "x": 740,
-        "y": 260,
-        "wires": [
-            [
-                "4b59cb1f.0b6074",
-                "9e15d26d.67d59"
-            ]
-        ]
-    },
-    {
-        "id": "5a67264f.b0d4a8",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "token",
-                "pt": "flow",
-                "to": "payload",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1050,
-        "y": 280,
-        "wires": [
-            [
-                "197f7fb8.eb7b3"
-            ]
-        ]
-    },
-    {
-        "id": "9e15d26d.67d59",
-        "type": "debug",
-        "z": "f8297485.d32748",
-        "name": "Debug: Login",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "x": 880,
-        "y": 240,
-        "wires": []
-    },
-    {
-        "id": "4b59cb1f.0b6074",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Add Bearer",
-        "func": "msg.payload = \"bearer \" + msg.payload.token;\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 880,
-        "y": 280,
-        "wires": [
-            [
-                "5a67264f.b0d4a8"
-            ]
-        ]
-    },
-    {
-        "id": "385053da.ffefdc",
-        "type": "config",
-        "z": "f8297485.d32748",
-        "name": "Configuration",
-        "properties": [
-            {
-                "p": "pollminute",
-                "pt": "flow",
-                "to": "50",
-                "tot": "str"
-            }
-        ],
-        "active": true,
-        "x": 110,
-        "y": 40,
-        "wires": []
-    },
-    {
-        "id": "a33f45a0.ca8a88",
-        "type": "inject",
-        "z": "f8297485.d32748",
-        "name": "Build JSON",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "0.1",
-        "x": 110,
-        "y": 140,
-        "wires": [
-            [
-                "4779bbf2.421be4"
-            ]
-        ]
-    },
-    {
-        "id": "eca68eef.a7038",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Create Login JSON",
-        "func": "msg.payload = {\n  \"username\": msg.username,\n  \"password\": msg.password,\n  \"rememberMe\": \"true\"\n};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 470,
-        "y": 100,
-        "wires": [
-            [
-                "39f969.672e1698"
-            ]
-        ]
-    },
-    {
-        "id": "b72628a.cba9fd8",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Create Read Request JSON",
-        "func": "msg.payload = {\n  \"ESIID\": msg.esiid,\n  \"MeterNumber\": msg.meternumber\n};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 500,
-        "y": 140,
-        "wires": [
-            [
-                "896ca32e.dd642"
-            ]
-        ]
-    },
-    {
-        "id": "4f766b51.f67344",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Create Read Result JSON",
-        "func": "msg.payload = {\n  \"ESIID\": msg.esiid\n};\nreturn msg;",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 490,
-        "y": 180,
-        "wires": [
-            [
-                "33a32576.b8d44a"
-            ]
-        ]
-    },
-    {
-        "id": "49de2e1c.6a2d7",
-        "type": "switch",
-        "z": "f8297485.d32748",
-        "name": "Waiting for Response",
-        "property": "readrequested",
-        "propertyType": "flow",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "1",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 340,
-        "y": 460,
-        "wires": [
-            [
-                "f805b5.98485a48"
-            ]
-        ]
-    },
-    {
-        "id": "f35231ec.019d9",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Not Waiting for Response",
-        "rules": [
-            {
-                "t": "set",
-                "p": "readrequested",
-                "pt": "flow",
-                "to": "0",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1120,
-        "y": 480,
-        "wires": [
-            [
-                "3322aadb.931d76"
-            ]
-        ]
-    },
-    {
-        "id": "ad13942f.9299a8",
-        "type": "mqtt out",
-        "z": "f8297485.d32748",
-        "name": "MQTT: Send Reading",
-        "topic": "smt/reading",
-        "qos": "",
-        "retain": "true",
-        "broker": "",
-        "x": 1530,
-        "y": 500,
-        "wires": []
-    },
-    {
-        "id": "3322aadb.931d76",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Parse Reading",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "payload.data.odrread",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1330,
-        "y": 480,
-        "wires": [
-            [
-                "ad13942f.9299a8",
-                "63ab6c38.0d5f84"
-            ]
-        ]
-    },
-    {
-        "id": "aa6c2a69.104ae8",
-        "type": "inject",
-        "z": "f8297485.d32748",
-        "name": "Read Meter",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "repeat": "1",
-        "crontab": "",
-        "once": false,
-        "onceDelay": "0.1",
-        "x": 110,
-        "y": 360,
-        "wires": [
-            [
-                "aa52a1f.5e5c56"
-            ]
-        ]
-    },
-    {
-        "id": "1e663d0f.337c23",
-        "type": "https-node",
-        "z": "f8297485.d32748",
-        "name": "Request Read",
-        "method": "POST",
-        "ret": "obj",
-        "url": "https://smartmetertexas.com/api/ondemandread",
-        "authorized": false,
-        "agent": true,
-        "x": 760,
-        "y": 360,
-        "wires": [
-            [
-                "8a692061.c38d8",
-                "616cab00.8d1ed4"
-            ]
-        ]
-    },
-    {
-        "id": "39f969.672e1698",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "authjson",
-                "pt": "flow",
-                "to": "payload",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 720,
-        "y": 100,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "896ca32e.dd642",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "readjson",
-                "pt": "flow",
-                "to": "payload",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 720,
-        "y": 140,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "33a32576.b8d44a",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "",
-        "rules": [
-            {
-                "t": "set",
-                "p": "resultjson",
-                "pt": "flow",
-                "to": "payload",
-                "tot": "msg"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 730,
-        "y": 180,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "8a692061.c38d8",
-        "type": "switch",
-        "z": "f8297485.d32748",
-        "name": "Request Good",
-        "property": "payload.data.statusReason",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "Request submitted successfully for further processing",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 940,
-        "y": 380,
-        "wires": [
-            [
-                "41ccc9f0.cb5378"
-            ]
-        ]
-    },
-    {
-        "id": "41ccc9f0.cb5378",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Waiting for Response",
-        "rules": [
-            {
-                "t": "set",
-                "p": "readrequested",
-                "pt": "flow",
-                "to": "1",
-                "tot": "str"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1140,
-        "y": 380,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "ba8a2ae2.a4c338",
-        "type": "debug",
-        "z": "f8297485.d32748",
-        "name": "Debug: Get Reading",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "x": 910,
-        "y": 440,
-        "wires": []
-    },
-    {
-        "id": "a411cabf.0a9678",
-        "type": "change",
-        "z": "f8297485.d32748",
-        "name": "Apply HTTP Config",
-        "rules": [
-            {
-                "t": "set",
-                "p": "payload",
-                "pt": "msg",
-                "to": "readjson",
-                "tot": "flow"
-            },
-            {
-                "t": "set",
-                "p": "headers.content-type",
-                "pt": "msg",
-                "to": "application/json",
-                "tot": "str"
-            },
-            {
-                "t": "set",
-                "p": "headers.authorization",
-                "pt": "msg",
-                "to": "token",
-                "tot": "flow"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 570,
-        "y": 360,
-        "wires": [
-            [
-                "1e663d0f.337c23"
-            ]
-        ]
-    },
-    {
-        "id": "616cab00.8d1ed4",
-        "type": "debug",
-        "z": "f8297485.d32748",
-        "name": "Debug: Read Meter",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "x": 950,
-        "y": 340,
-        "wires": []
-    },
-    {
-        "id": "197f7fb8.eb7b3",
-        "type": "debug",
-        "z": "f8297485.d32748",
-        "name": "Debug: Auth Token",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "x": 1240,
-        "y": 280,
-        "wires": []
-    },
-    {
-        "id": "63ab6c38.0d5f84",
-        "type": "debug",
-        "z": "f8297485.d32748",
-        "name": "Debug: Last Reading",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "x": 1530,
-        "y": 460,
-        "wires": []
-    },
-    {
-        "id": "663ac43a.779abc",
-        "type": "rbe",
-        "z": "f8297485.d32748",
-        "name": "",
-        "func": "rbe",
-        "gap": "",
-        "start": "",
-        "inout": "out",
-        "property": "payload",
-        "x": 410,
-        "y": 360,
-        "wires": [
-            [
-                "a411cabf.0a9678"
-            ]
-        ]
-    },
-    {
-        "id": "aa52a1f.5e5c56",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Check Time",
-        "func": "var date = new Date();\nvar minute = (\"0\"+date.getMinutes()).substr(-2);\nvar hour = (\"0\"+date.getHours()).substr(-2);\n\nvar values = flow.get([\"pollminute\"]);\nvar poll = values[0];\n\nif (minute == poll){\n    return { payload : hour };\n}\n",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 270,
-        "y": 360,
-        "wires": [
-            [
-                "663ac43a.779abc"
-            ]
-        ]
-    },
-    {
-        "id": "a4d10d90.f8dae",
-        "type": "function",
-        "z": "f8297485.d32748",
-        "name": "Check Time",
-        "func": "var date = new Date();\nvar minute = (\"0\"+date.getMinutes()).substr(-2);\nvar hour = (\"0\"+date.getHours()).substr(-2);\n\nvar values = flow.get([\"pollminute\"]);\nvar poll = values[0];\n\nif (poll === 0 & minute == 59){\n    return { payload : hour };\n}\n\nelse if (minute == poll - 1){\n    return { payload : hour };\n}\n",
-        "outputs": 1,
-        "noerr": 0,
-        "x": 280,
-        "y": 260,
-        "wires": [
-            [
-                "1b6c236b.153bbd"
-            ]
-        ]
-    },
-    {
-        "id": "1b6c236b.153bbd",
-        "type": "rbe",
-        "z": "f8297485.d32748",
-        "name": "",
-        "func": "rbe",
-        "gap": "",
-        "start": "",
-        "inout": "out",
-        "property": "payload",
-        "x": 420,
-        "y": 260,
-        "wires": [
-            [
-                "8f12d0a3.66f63"
-            ]
-        ]
-    },
-    {
-        "id": "4779bbf2.421be4",
-        "type": "credentials",
-        "z": "f8297485.d32748",
-        "name": "Credentials",
-        "props": [
-            {
-                "value": "username",
-                "type": "msg"
-            },
-            {
-                "value": "password",
-                "type": "msg"
-            },
-            {
-                "value": "esiid",
-                "type": "msg"
-            },
-            {
-                "value": "meternumber",
-                "type": "msg"
-            }
-        ],
-        "x": 270,
-        "y": 140,
-        "wires": [
-            [
-                "eca68eef.a7038",
-                "b72628a.cba9fd8",
-                "4f766b51.f67344"
-            ]
-        ]
-    }
-]
+        "type": "str",
+        "expression": "0 49 * * * * "
+    }],
+    "x": 110,
+    "y": 260,
+    "wires": [
+        ["8f12d0a3.66f63"]
+    ]
+}, {
+    "id": "8e5e4167.3de6a",
+    "type": "ha-entity",
+    "z": "f8297485.d32748",
+    "name": "SMT Current Reading",
+    "server": "",
+    "version": 1,
+    "debugenabled": false,
+    "outputs": 1,
+    "entityType": "sensor",
+    "config": [{
+        "property": "name",
+        "value": "SMT Current Reading"
+    }, {
+        "property": "device_class",
+        "value": "energy"
+    }, {
+        "property": "icon",
+        "value": ""
+    }, {
+        "property": "unit_of_measurement",
+        "value": "kWh"
+    }],
+    "state": "payload.data.odrread",
+    "stateType": "msg",
+    "attributes": [{
+        "property": "odr_date",
+        "value": "payload.data.odrdate",
+        "valueType": "str"
+    }, {
+        "property": "odr_usage",
+        "value": "payload.data.odrusage",
+        "valueType": "str"
+    }],
+    "resend": true,
+    "outputLocation": "",
+    "outputLocationType": "none",
+    "inputOverride": "block",
+    "x": 1340,
+    "y": 480,
+    "wires": [
+        []
+    ]
+}]

--- a/smartmetertexas.yaml
+++ b/smartmetertexas.yaml
@@ -1,9 +1,4 @@
 sensor:
-
-  - platform: mqtt
-    name: SMT Current Reading
-    state_topic: "smt/reading"
-    unit_of_measurement: "kWh"
     
   - platform: template
     sensors:


### PR DESCRIPTION
Thanks for pulling this together! I finally gave up on the native Home Assistant integration and implemented this.

I made a few tweaks to simplify so I wanted to share it back in case you wanted to include:

1. Use [Cron+](https://flows.nodered.org/node/node-red-contrib-cron-plus) nodes to simplify the timing logic to 1 node instead of 3.
2. Use Home Assistant Websocket (and HACS Add-on) to add a native Home Assistant sensor with extra attributes and device class instead of going through MQTT.

No worries if you don't want to use it, just thought I'd share.